### PR TITLE
Build job fixed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,16 +9,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: arm-none-eabi-gcc
-      uses: fiam/arm-none-eabi-gcc@v1
-      with:
-        release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
-        
-    - name: Install srecord and setuptools
-      run: sudo apt install srecord python3-setuptools
-    
-    - name: Install nrfutil
-      run: sudo -H pip3 install --upgrade pip && sudo -H pip3 install nrfutil
 
     - name: make
-      run: cd ./firmware && make
+      run: docker run -v $(pwd):/workspace ghcr.io/charliebruce/nrf5-docker-build:sdk-16.0.0 bash -c "cd /workspace/firmware && make"

--- a/firmware/nRF5_SDK_16.0.0/components/toolchain/gcc/Makefile.posix
+++ b/firmware/nRF5_SDK_16.0.0/components/toolchain/gcc/Makefile.posix
@@ -1,7 +1,3 @@
-#GNU_INSTALL_ROOT ?= /usr/local/gcc-arm-none-eabi-7-2018-q2-update/bin/
-#GNU_VERSION ?= 7.3.1
-#GNU_PREFIX ?= arm-none-eabi
-
-#GNU_INSTALL_ROOT := /usr/local/gcc-arm-none-eabi-4_9-2015q3
-GNU_VERSION := 4.9.3
-GNU_PREFIX := arm-none-eabi
+GNU_INSTALL_ROOT ?= /usr/local/gcc-arm-none-eabi-7-2018-q2-update/bin/
+GNU_VERSION ?= 7.3.1
+GNU_PREFIX ?= arm-none-eabi


### PR DESCRIPTION
This fixes the Build job, as in https://github.com/OpenSource-EBike-firmware/ebike_wireless_remote/pull/26

The bootloader doesn't need the ANT keys so this is ready to merge as-is, no need to add secrets.